### PR TITLE
all: migrate to gonum.org/v1/hdf5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ matrix:
  allow_failures:
    - go: master
 
+go_import_path: gonum.org/v1/hdf5
+
 sudo: false
 
 addons:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hdf5
 
 [![Build Status](https://secure.travis-ci.org/gonum/hdf5.png)](http://travis-ci.org/gonum/hdf5)
-[![GoDoc](https://godoc.org/github.com/gonum/hdf5?status.svg)](https://godoc.org/github.com/gonum/hdf5)
+[![GoDoc](https://godoc.org/gonum.org/v1/hdf5?status.svg)](https://godoc.org/gonum.org/v1/hdf5)
 
 Naive ``cgo`` bindings for the ``C-API`` of ``hdf5``.
 
@@ -11,9 +11,9 @@ Naive ``cgo`` bindings for the ``C-API`` of ``hdf5``.
 
 ## Example
 
-- Hello world example: https://github.com/gonum/hdf5/blob/master/cmd/test-go-hdf5/main.go
+- Hello world example: [cmd/test-go-hdf5/main.go](https://github.com/gonum/hdf5/blob/master/cmd/test-go-hdf5/main.go)
 
-- Writing/reading an ``hdf5`` with compound data: https://github.com/gonum/hdf5/blob/master/cmd/test-go-cpxcmpd/main.go
+- Writing/reading an ``hdf5`` with compound data: [cmd/test-go-cpxcmpd/main.go](https://github.com/gonum/hdf5/blob/master/cmd/test-go-cpxcmpd/main.go)
 
 ## Note
 

--- a/cmd/test-go-cpxcmpd/main.go
+++ b/cmd/test-go-cpxcmpd/main.go
@@ -7,7 +7,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/gonum/hdf5"
+	"gonum.org/v1/hdf5"
 )
 
 const (

--- a/cmd/test-go-extend-ds/main.go
+++ b/cmd/test-go-extend-ds/main.go
@@ -7,7 +7,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/gonum/hdf5"
+	"gonum.org/v1/hdf5"
 )
 
 func main() {

--- a/cmd/test-go-hdf5/main.go
+++ b/cmd/test-go-hdf5/main.go
@@ -7,7 +7,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/gonum/hdf5"
+	"gonum.org/v1/hdf5"
 )
 
 func main() {

--- a/cmd/test-go-table-01-readback/main.go
+++ b/cmd/test-go-table-01-readback/main.go
@@ -7,7 +7,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/gonum/hdf5"
+	"gonum.org/v1/hdf5"
 )
 
 const (

--- a/cmd/test-go-table-01/main.go
+++ b/cmd/test-go-table-01/main.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/gonum/hdf5"
+	"gonum.org/v1/hdf5"
 )
 
 const (

--- a/hdf5.go
+++ b/hdf5.go
@@ -3,7 +3,7 @@
 // license that can be found in the LICENSE file.
 
 // Package hdf5 provides access to the HDF5 C library.
-package hdf5
+package hdf5 // import "gonum.org/v1/hdf5"
 
 // #include "hdf5.h"
 import "C"


### PR DESCRIPTION
This CL migrates github.com/gonum/hdf5 to gonum.org/v1/hdf5.
It also makes sure people import it from that new location.

Fixes gonum/hdf5#3.