### PR TITLE
travis: enable fast-finish mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ go:
   - master
 
 matrix:
+ fast_finish: true
  allow_failures:
    - go: master
 


### PR DESCRIPTION
This CL enables the fast-finish mode for travis.
See:
 https://blog.travis-ci.com/2013-11-27-fast-finishing-builds/