### PR TITLE
Add Support for PacketTable Append

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 language: go
 go:
-  - 1.5.x
-  - 1.6.x
-  - 1.7.x
   - 1.8.x
   - 1.9.x
+  - 1.10.x
   - master
 
 matrix:

--- a/h5pt_test.go
+++ b/h5pt_test.go
@@ -11,33 +11,104 @@ import (
 import "testing"
 
 const (
-	fname    string = "ex_table_01.h5"
-	tname    string = "table"
-	nrecords int    = 8
+	fname     string = "ex_table_01.h5"
+	tname     string = "table"
+	chunkSize int    = 10
+	compress  int    = 0
 )
 
 type particle struct {
-	// name        string  `hdf5:"Name"`      // FIXME(sbinet)
+	//name        string  `hdf5:"Name"`		 // FIXME(TacoVox)
+	vehicle_no  uint8   `hdf5:"Vehicle Number"`
+	sattelites  int8    `hdf5:"Sattelites"`
+	cars_no     int16   `hdf5:"Number of Cars"`
+	trucks_no   int16   `hdf5:"Number of Trucks"`
+	min_speed   uint32  `hdf5:"Minimum Speed"`
 	lati        int32   `hdf5:"Latitude"`
+	max_speed   uint64  `hdf5:"Maximum Speed"`
 	longi       int64   `hdf5:"Longitude"`
 	pressure    float32 `hdf5:"Pressure"`
 	temperature float64 `hdf5:"Temperature"`
+	accurate    bool    `hdf5:"Accurate"`
 	// isthep      []int                     // FIXME(sbinet)
 	// jmohep [2][2]int64                    // FIXME(sbinet)
 }
 
-func TestTable(t *testing.T) {
+func testTable(t *testing.T, dType interface{}, data interface{}, nrecords int) {
+	var table *Table
 
+	typeString := reflect.TypeOf(data).String()
+
+	// create a new file using default properties
+	f, err := CreateFile(fname, F_ACC_TRUNC)
+	if err != nil {
+		t.Fatalf("CreateFile failed for %s: %s", typeString, err)
+	}
+	defer os.Remove(fname)
+	defer f.Close()
+
+	table, err = f.CreateTableFrom(tname, dType, chunkSize, compress)
+	if err != nil {
+		t.Fatalf("CreateTableFrom struct failed for %s: %s", typeString, err)
+	}
+	defer table.Close()
+
+	if !table.IsValid() {
+		t.Fatalf("PacketTable %q is invalid for %s.", tname, typeString)
+	}
+
+	// write one packet to the packet table
+	if err = table.Append(data); err != nil {
+		t.Fatalf("Append failed with single packet for %s: %s", typeString, err)
+	}
+
+	// get the number of packets
+	n, err := table.NumPackets()
+	if err != nil {
+		t.Fatalf("NumPackets failed for %s: %s", typeString, err)
+	}
+	if n != nrecords {
+		t.Fatalf("Wrong number of packets reported for %s, expected %d but got %d", typeString, nrecords, n)
+	}
+
+	// iterate through packets
+	for i := 0; i != n; i++ {
+		p := make([]interface{}, 1)
+		if err = table.Next(&p); err != nil {
+			t.Fatalf("Next failed for %s: %s", typeString, err)
+		}
+	}
+
+	// For now just conduct the "old" test case // FIXME(TacoVox)
+	if reflect.TypeOf(data).String() != "[]hdf5.particle" {
+		return
+	}
+
+	// reset index
+	table.CreateIndex()
+
+	readdata := make([]particle, nrecords)
+
+	if err = table.ReadPackets(0, nrecords, &readdata); err != nil {
+		t.Fatalf("ReadPackets failed for %s: %s", typeString, err)
+	}
+
+	if !reflect.DeepEqual(readdata, data) {
+		t.Fatalf("Data differs for %s.\ngot= %#v\nwant=%#v\n", typeString, readdata, data)
+	}
+}
+
+func TestPTStruct(t *testing.T) {
 	// define an array of particles
 	particles := []particle{
-		{0, 0, 0.0, 0.},
-		{10, 10, 1.0, 10.},
-		{20, 20, 2.0, 20.},
-		{30, 30, 3.0, 30.},
-		{40, 40, 4.0, 40.},
-		{50, 50, 5.0, 50.},
-		{60, 60, 6.0, 60.},
-		{70, 70, 7.0, 70.},
+		{0, 0, 0, 0, 0, 0, 0, 0, 0.0, 0.0, false},
+		{10, 10, 10, 10, 10, 10, 10, 10, 1.0, 10.0, false},
+		{20, 20, 20, 20, 20, 20, 20, 20, 2.0, 20.0, false},
+		{30, 30, 30, 30, 30, 30, 30, 30, 3.0, 30.0, false},
+		{40, 40, 40, 40, 40, 40, 40, 40, 4.0, 40.0, true},
+		{50, 50, 50, 50, 50, 50, 50, 50, 5.0, 50.0, true},
+		{60, 60, 60, 60, 60, 60, 60, 60, 6.0, 60.0, true},
+		{70, 70, 70, 70, 70, 70, 70, 70, 7.0, 70.0, true},
 	}
 	// particles := []particle{
 	// 	{"zero", 0, 0, 0.0, 0., []int{0, 0}, [2][2]int{{0, 0}, {0, 0}}},
@@ -50,64 +121,82 @@ func TestTable(t *testing.T) {
 	// 	{"seven", 70, 70, 7.0, 70., []int{0, 0}, [2][2]int{{7, 0}, {0, 7}}},
 	// }
 
-	chunkSize := 10
-	compress := 0
+	testTable(t, particle{}, particles[0], 1)
 
-	// create a new file using default properties
-	f, err := CreateFile(fname, F_ACC_TRUNC)
-	if err != nil {
-		t.Fatalf("CreateFile failed: %s", err)
-	}
-	defer os.Remove(fname)
-	defer f.Close()
-
-	// create a fixed-length packet table within the file
-	table, err := f.CreateTableFrom(tname, particle{}, chunkSize, compress)
-	if err != nil {
-		t.Fatalf("CreateTableFrom failed: %s", err)
-	}
-	defer table.Close()
-
-	if !table.IsValid() {
-		t.Fatal("table is invalid")
-	}
-
-	// write one packet to the packet table
-	if err = table.Append(&particles[0]); err != nil {
-		t.Fatalf("Append failed with single packet: %s", err)
-	}
-
-	// write several packets
 	parts := particles[1:]
-	if err = table.Append(&parts); err != nil {
-		t.Fatalf("Append failed with multiple packets: %s", err)
-	}
+	testTable(t, particle{}, parts, 7)
+}
 
-	// get the number of packets
-	n, err := table.NumPackets()
-	if err != nil {
-		t.Fatalf("NumPackets failed: %s", err)
-	}
-	if n != nrecords {
-		t.Fatalf("Wrong number of packets reported, expected %d but got %d", nrecords, n)
-	}
+func TestPTableBasic(t *testing.T) {
+	// INT8
+	i8s := []int8{-3, -2, -1, 0, 1, 2, 3, 4}
+	testTable(t, T_NATIVE_INT8, i8s[0], 1)
+	i8sub := i8s[1:]
+	testTable(t, T_NATIVE_INT8, i8sub, 7)
 
-	// iterate through packets
-	for i := 0; i != n; i++ {
-		p := make([]particle, 1)
-		if err := table.Next(&p); err != nil {
-			t.Fatalf("Next failed: %s", err)
-		}
-	}
+	// INT16
+	i16s := []int16{-3, -2, -1, 0, 1, 2, 3, 4}
+	testTable(t, T_NATIVE_INT16, i16s[0], 1)
+	i16sub := i16s[1:]
+	testTable(t, T_NATIVE_INT16, i16sub, 7)
 
-	// reset index
-	table.CreateIndex()
-	parts = make([]particle, nrecords)
-	if err = table.ReadPackets(0, nrecords, &parts); err != nil {
-		t.Fatalf("ReadPackets failed: %s", err)
-	}
+	// INT32
+	i32s := []int32{-3, -2, -1, 0, 1, 2, 3, 4}
+	testTable(t, T_NATIVE_INT32, i32s[0], 1)
+	i32sub := i32s[1:]
+	testTable(t, T_NATIVE_INT32, i32sub, 7)
 
-	if !reflect.DeepEqual(parts, particles) {
-		t.Fatalf("particles differ.\ngot= %#v\nwant=%#v\n", parts, particles)
-	}
+	// INT64
+	i64s := []int64{-3, -2, -1, 0, 1, 2, 3, 4}
+	testTable(t, T_NATIVE_INT64, i64s[0], 1)
+	i64sub := i64s[1:]
+	testTable(t, T_NATIVE_INT64, i64sub, 7)
+
+	// UINT8
+	ui8s := []uint8{0, 1, 2, 3, 4, 5, 6, 7}
+	testTable(t, T_NATIVE_UINT8, ui8s[0], 1)
+	ui8sub := ui8s[1:]
+	testTable(t, T_NATIVE_UINT8, ui8sub, 7)
+
+	// UINT16
+	ui16s := []uint16{0, 1, 2, 3, 4, 5, 6, 7}
+	testTable(t, T_NATIVE_UINT16, ui16s[0], 1)
+	ui16sub := ui16s[1:]
+	testTable(t, T_NATIVE_UINT16, ui16sub, 7)
+
+	// UINT32
+	ui32s := []uint32{0, 1, 2, 3, 4, 5, 6, 7}
+	testTable(t, T_NATIVE_UINT32, ui32s[0], 1)
+	ui32sub := ui32s[1:]
+	testTable(t, T_NATIVE_UINT32, ui32sub, 7)
+
+	// UINT64
+	ui64s := []uint64{0, 1, 2, 3, 4, 5, 6, 7}
+	testTable(t, T_NATIVE_UINT64, ui64s[0], 1)
+	ui64sub := ui64s[1:]
+	testTable(t, T_NATIVE_UINT64, ui64sub, 7)
+
+	// FLOAT32
+	f32s := []float32{0., 1., 2., 3., 4., 5., 6., 7.}
+	testTable(t, T_NATIVE_FLOAT, f32s[0], 1)
+	f32sub := f32s[1:]
+	testTable(t, T_NATIVE_FLOAT, f32sub, 7)
+
+	// FLOAT64
+	f64s := []float64{0., 1., 2., 3., 4., 5., 6., 7.}
+	testTable(t, T_NATIVE_DOUBLE, f64s[0], 1)
+	f64sub := f64s[1:]
+	testTable(t, T_NATIVE_DOUBLE, f64sub, 7)
+
+	// BOOL
+	bs := []bool{false, true, false, true, false, true, false, true}
+	testTable(t, T_NATIVE_HBOOL, bs[0], 1)
+	bsub := bs[1:]
+	testTable(t, T_NATIVE_HBOOL, bsub, 7)
+
+	// STRING
+	strs := []string{"zero", "one", "two", "three", "four", "five", "six", "seven"}
+	testTable(t, T_GO_STRING, strs[0], 1)
+	strsub := strs[1:]
+	testTable(t, T_GO_STRING, strsub, 7)
 }

--- a/h5t.go
+++ b/h5t.go
@@ -41,6 +41,9 @@ const (
 // list of go types
 var (
 	_go_string_t reflect.Type = reflect.TypeOf(string(""))
+
+	_go_boolean_t reflect.Type = reflect.TypeOf(bool(false))
+
 	_go_int_t    reflect.Type = reflect.TypeOf(int(0))
 	_go_int8_t   reflect.Type = reflect.TypeOf(int8(0))
 	_go_int16_t  reflect.Type = reflect.TypeOf(int16(0))
@@ -402,6 +405,9 @@ func NewDataTypeFromType(t reflect.Type) (*Datatype, error) {
 
 	case reflect.String:
 		dt, err = T_GO_STRING.Copy()
+
+	case reflect.Bool:
+		dt, err = T_NATIVE_HBOOL.Copy()
 
 	case reflect.Array:
 		elem_type, err := NewDataTypeFromType(t.Elem())


### PR DESCRIPTION
As you guys stated on your front page, the PT interface was/is broken.
With a colleague, I went ahead and improved to things:
-  Removed `H5Pcreate_fl` and added the `H5Pcreate` as this is marked as deprecated by the official HDF5 documentation. As a matter of fact, I faced various issues, when trying to use variable lenght strings with `H5Pcreate_fl`.
- Fixed the Append function. There were countless issues with pointers and with the correct value representation in C that were fixed. I think the code will speak for itself.

Please consider this pull request.