### PR TITLE
(H5PT) Improved Append() Method

### DIFF
--- a/cmd/test-go-table-01-readback/main.go
+++ b/cmd/test-go-table-01-readback/main.go
@@ -19,16 +19,16 @@ const (
 
 type particle struct {
 	// name        string  `hdf5:"Name"`      // FIXME(sbinet)
-	lati        int32   `hdf5:"Latitude"`
-	longi       int64   `hdf5:"Longitude"`
-	pressure    float32 `hdf5:"Pressure"`
-	temperature float64 `hdf5:"Temperature"`
+	Lati        int32   `hdf5:"Latitude"`
+	Longi       int64   `hdf5:"Longitude"`
+	Pressure    float32 `hdf5:"Pressure"`
+	Temperature float64 `hdf5:"Temperature"`
 	// isthep      []int                     // FIXME(sbinet)
 	// jmohep [2][2]int64                    // FIXME(sbinet)
 }
 
 func (p *particle) Equal(o *particle) bool {
-	return p.lati == o.lati && p.longi == o.longi && p.pressure == o.pressure && p.temperature == o.temperature
+	return p.Lati == o.Lati && p.Longi == o.Longi && p.Pressure == o.Pressure && p.Temperature == o.Temperature
 }
 
 func main() {

--- a/cmd/test-go-table-01/main.go
+++ b/cmd/test-go-table-01/main.go
@@ -19,10 +19,10 @@ const (
 
 type particle struct {
 	// name        string  `hdf5:"Name"`      // FIXME(sbinet)
-	lati        int32   `hdf5:"Latitude"`
-	longi       int64   `hdf5:"Longitude"`
-	pressure    float32 `hdf5:"Pressure"`
-	temperature float64 `hdf5:"Temperature"`
+	Lati        int32   `hdf5:"Latitude"`
+	Longi       int64   `hdf5:"Longitude"`
+	Pressure    float32 `hdf5:"Pressure"`
+	Temperature float64 `hdf5:"Temperature"`
 	// isthep      []int                     // FIXME(sbinet)
 	// jmohep [2][2]int64                    // FIXME(sbinet)
 }

--- a/h5pt_test.go
+++ b/h5pt_test.go
@@ -7,8 +7,8 @@ package hdf5
 import (
 	"os"
 	"reflect"
+	"testing"
 )
-import "testing"
 
 const (
 	fname     string = "ex_table_01.h5"
@@ -18,20 +18,20 @@ const (
 )
 
 type particle struct {
-	//name        string  `hdf5:"Name"`		 // FIXME(TacoVox)
-	vehicle_no  uint8   `hdf5:"Vehicle Number"`
-	sattelites  int8    `hdf5:"Sattelites"`
-	cars_no     int16   `hdf5:"Number of Cars"`
-	trucks_no   int16   `hdf5:"Number of Trucks"`
-	min_speed   uint32  `hdf5:"Minimum Speed"`
-	lati        int32   `hdf5:"Latitude"`
-	max_speed   uint64  `hdf5:"Maximum Speed"`
-	longi       int64   `hdf5:"Longitude"`
-	pressure    float32 `hdf5:"Pressure"`
-	temperature float64 `hdf5:"Temperature"`
-	accurate    bool    `hdf5:"Accurate"`
-	// isthep      []int                     // FIXME(sbinet)
-	// jmohep [2][2]int64                    // FIXME(sbinet)
+	// Name        string  `hdf5:"Name"` // FIXME(TacoVox): ReadPackets seems to need an update
+	Vehicle_no  uint8   `hdf5:"Vehicle Number"`
+	Satellites  int8    `hdf5:"Satellites"`
+	Cars_no     int16   `hdf5:"Number of Cars"`
+	Trucks_no   int16   `hdf5:"Number of Trucks"`
+	Min_speed   uint32  `hdf5:"Minimum Speed"`
+	Lati        int32   `hdf5:"Latitude"`
+	Max_speed   uint64  `hdf5:"Maximum Speed"`
+	Longi       int64   `hdf5:"Longitude"`
+	Pressure    float32 `hdf5:"Pressure"`
+	Temperature float64 `hdf5:"Temperature"`
+	Accurate    bool    `hdf5:"Accurate"`
+	// isthep      []int       // FIXME(sbinet)
+	// jmohep      [2][2]int64 // FIXME(sbinet)
 }
 
 func testTable(t *testing.T, dType interface{}, data interface{}, nrecords int) {


### PR DESCRIPTION
To keep the fun alive :sunglasses: 

This patch features an improvement of the HDF5 PacketTable Append
method. This was necessary, because the old version did not support the
append of struct containing nested structs and/or slices/arrays.
To sum it up:
- Any data of any Compound Datatype can be written to a PacketTable now.
- This is achieved by allocating memory that contains the necessary
  data.
- The whole code is simpler than the doubled code that excisted before.
- The Append() method now supports proper appending of slices, which are
  not appended in a append-per-member manner, but rather as several
  objects to append that are consecutively in memory. This is more
  aligned with the offical way-of-doing.

What needs to be improved?
- The append of pointers still follows the old notion that we derefence
  the pointer and write the value directly. To support H5T_STD_REF_OBJ,
  further, significant changes have to be done to the whole code base.
- The read functionality has to be revised, as it seems to not work when
  strings are part of compound datatypes. Manual testing has shown that
  they are written properly, the test cases still would fail, because
  of the mentioned call to read.

I suggest that the above mentioned improvements are tackled in a separate patch.