### PR TITLE
[Experimental] Marshal C Data to []byte

### DIFF
--- a/cmd/test-go-table-01/main.go
+++ b/cmd/test-go-table-01/main.go
@@ -75,13 +75,14 @@ func main() {
 	}
 
 	// write one packet to the packet table
-	if err = table.Append(&particles[0]); err != nil {
+	if err = table.Append(particles[0]); err != nil {
 		panic(fmt.Errorf("Append failed with single packet: %s", err))
 	}
 
 	// write several packets
-	parts := particles[1:]
-	if err = table.Append(&parts); err != nil {
+	if err = table.Append(particles[1], particles[2], particles[3],
+		particles[4], particles[5], particles[6], particles[7],
+	); err != nil {
 		panic(fmt.Errorf("Append failed with multiple packets: %s", err))
 	}
 
@@ -109,7 +110,7 @@ func main() {
 
 	// reset index
 	table.CreateIndex()
-	parts = make([]particle, nrecords)
+	parts := make([]particle, nrecords)
 	if err = table.ReadPackets(0, nrecords, &parts); err != nil {
 		panic(fmt.Errorf("ReadPackets failed: %s", err))
 	}

--- a/cmem/cmem.go
+++ b/cmem/cmem.go
@@ -1,0 +1,13 @@
+// Copyright ©2018 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package cmem provides helper functionality for accessing memory in a C
+// compatible fashion.
+package cmem
+
+// CMarshaler is an interface for types that can marshal their data into a
+// C compatible binary layout.
+type CMarshaler interface {
+	MarshalC() ([]byte, error)
+}

--- a/cmem/encoder.go
+++ b/cmem/encoder.go
@@ -1,0 +1,167 @@
+// Copyright ©2018 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package cmem
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math"
+	"reflect"
+	"unsafe"
+)
+
+var nativeEndian binary.ByteOrder
+
+func init() {
+	one := uint16(0x1)
+	nativeEndian = [...]binary.ByteOrder{
+		binary.BigEndian,
+		binary.LittleEndian,
+	}[(*[2]byte)(unsafe.Pointer(&one))[0]]
+}
+
+// Encoder is a wrapper type for information necessary to create and
+// subsequently write an in memory object to a PacketTable using Append().
+type Encoder struct {
+	// Buf contains the encoded data.
+	Buf    []byte
+	offset int
+}
+
+// Encode encodes the value passed as data to binary form stored in []Buf. This
+// buffer is a Go representation of a C in-memory object that can be appended
+// to e.g. a HDF5 PacketTable.
+//
+// Struct values must only have exported fields, otherwise Encode will panic.
+func (enc *Encoder) Encode(data interface{}) error {
+	padding := enc.offset - len(enc.Buf)
+
+	if padding > 0 {
+		enc.Buf = append(enc.Buf, make([]byte, padding)...)
+	}
+
+	if data, ok := data.(CMarshaler); ok {
+		raw, err := data.MarshalC()
+		if err != nil {
+			return err
+		}
+
+		enc.Buf = append(enc.Buf, raw...)
+
+		return nil
+	}
+
+	rv := reflect.Indirect(reflect.ValueOf(data))
+	rt := rv.Type()
+
+	switch rt.Kind() {
+	case reflect.Slice, reflect.Array:
+		for i := 0; i < rv.Len(); i++ {
+			if err := enc.Encode(rv.Index(i).Interface()); err != nil {
+				return err
+			}
+		}
+		return nil
+
+	case reflect.Struct:
+		offset := enc.offset
+		for i := 0; i < rv.NumField(); i++ {
+			sfv := rv.Field(i).Interface()
+			// In order to keep the memory offset always correct, we use the
+			// structs offset.
+			enc.offset = offset + int(rt.Field(i).Offset)
+			if err := enc.Encode(sfv); err != nil {
+				return err
+			}
+			// Reset the offset to the correct array size.
+			enc.offset = offset + int(rt.Size())
+		}
+		return nil
+
+	case reflect.String:
+		str := append([]byte(rv.String()), 0)
+
+		// This direct machine conversion is only used
+		// because HDF5 uses machine endianism.
+		//
+		// DO NOT DO THIS AT HOME.
+		//
+		raw := (*[unsafe.Sizeof(uintptr(0))]byte)(unsafe.Pointer(&str))
+		enc.Buf = append(enc.Buf, raw[:]...)
+		enc.offset += len(raw)
+
+	case reflect.Ptr:
+		return enc.Encode(rv.Elem())
+
+	case reflect.Int8:
+		enc.Buf = append(enc.Buf, byte(rv.Int()))
+		enc.offset++
+
+	case reflect.Uint8:
+		enc.Buf = append(enc.Buf, byte(rv.Uint()))
+		enc.offset++
+
+	case reflect.Int16:
+		var raw [2]byte
+		nativeEndian.PutUint16(raw[:], uint16(rv.Int()))
+		enc.Buf = append(enc.Buf, raw[:]...)
+		enc.offset += 2
+
+	case reflect.Uint16:
+		var raw [2]byte
+		nativeEndian.PutUint16(raw[:], uint16(rv.Uint()))
+		enc.Buf = append(enc.Buf, raw[:]...)
+		enc.offset += 2
+
+	case reflect.Int32:
+		var raw [4]byte
+		nativeEndian.PutUint32(raw[:], uint32(rv.Int()))
+		enc.Buf = append(enc.Buf, raw[:]...)
+		enc.offset += 4
+
+	case reflect.Uint32:
+		var raw [4]byte
+		nativeEndian.PutUint32(raw[:], uint32(rv.Uint()))
+		enc.Buf = append(enc.Buf, raw[:]...)
+		enc.offset += 4
+
+	case reflect.Int64:
+		var raw [8]byte
+		nativeEndian.PutUint64(raw[:], uint64(rv.Int()))
+		enc.Buf = append(enc.Buf, raw[:]...)
+		enc.offset += 8
+
+	case reflect.Uint64:
+		var raw [8]byte
+		nativeEndian.PutUint64(raw[:], uint64(rv.Uint()))
+		enc.Buf = append(enc.Buf, raw[:]...)
+		enc.offset += 8
+
+	case reflect.Float32:
+		var raw [4]byte
+		nativeEndian.PutUint32(raw[:], math.Float32bits(float32(rv.Float())))
+		enc.Buf = append(enc.Buf, raw[:]...)
+		enc.offset += 4
+
+	case reflect.Float64:
+		var raw [8]byte
+		nativeEndian.PutUint64(raw[:], math.Float64bits(rv.Float()))
+		enc.Buf = append(enc.Buf, raw[:]...)
+		enc.offset += 8
+
+	case reflect.Bool:
+		val := byte(0)
+		if rv.Bool() {
+			val = 1
+		}
+		enc.Buf = append(enc.Buf, val)
+		enc.offset++
+
+	default:
+		return fmt.Errorf("hdf5: PT Append does not support datatype (%s)", rt.Kind())
+	}
+
+	return nil
+}

--- a/cmem/encoder_test.go
+++ b/cmem/encoder_test.go
@@ -1,0 +1,56 @@
+// Copyright ©2018 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package cmem
+
+import (
+	"bytes"
+	"encoding/binary"
+	"strconv"
+	"testing"
+)
+
+func TestEncode(t *testing.T) {
+	for i, tc := range []struct {
+		v    interface{}
+		want []byte
+	}{
+		{
+			v: struct {
+				V1 uint8
+				V2 uint64
+				V3 uint8
+				V4 uint16
+			}{1, 2, 3, 4},
+			want: []byte{
+				0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // |........|
+				0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // |........|
+				0x03, 0x00, 0x04, 0x00, /*                   */ // |....|
+			},
+		},
+		{
+			v: []int32{1, 20, 300, 4000, 50000, 600000, 7000000, 8000000},
+			want: []byte{
+				0x01, 0x00, 0x00, 0x00, 0x14, 0x00, 0x00, 0x00, // |........|
+				0x2c, 0x01, 0x00, 0x00, 0xa0, 0x0f, 0x00, 0x00, // |,.......|
+				0x50, 0xc3, 0x00, 0x00, 0xc0, 0x27, 0x09, 0x00, // |P....'..|
+				0xc0, 0xcf, 0x6a, 0x00, 0x00, 0x12, 0x7a, 0x00, // |..j...z.|
+			},
+		},
+	} {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			oldEndian := nativeEndian
+			nativeEndian = binary.LittleEndian
+			defer func() { oldEndian = nativeEndian }()
+			var enc Encoder
+			err := enc.Encode(tc.v)
+			if err != nil {
+				t.Fatalf("could not encode: %v", err)
+			}
+			if !bytes.Equal(enc.Buf, tc.want) {
+				t.Fatalf("encoding error:\ngot = %v\nwant= %v", enc.Buf, tc.want)
+			}
+		})
+	}
+}

--- a/h5pt_test.go
+++ b/h5pt_test.go
@@ -34,7 +34,7 @@ type particle struct {
 	// jmohep      [2][2]int64 // FIXME(sbinet)
 }
 
-func testTable(t *testing.T, dType interface{}, data interface{}, nrecords int) {
+func testTable(t *testing.T, dType interface{}, data ...interface{}) {
 	var table *Table
 
 	typeString := reflect.TypeOf(data).String()
@@ -58,7 +58,7 @@ func testTable(t *testing.T, dType interface{}, data interface{}, nrecords int) 
 	}
 
 	// write one packet to the packet table
-	if err = table.Append(data); err != nil {
+	if err = table.Append(data...); err != nil {
 		t.Fatalf("Append failed with single packet for %s: %s", typeString, err)
 	}
 
@@ -67,8 +67,8 @@ func testTable(t *testing.T, dType interface{}, data interface{}, nrecords int) 
 	if err != nil {
 		t.Fatalf("NumPackets failed for %s: %s", typeString, err)
 	}
-	if n != nrecords {
-		t.Fatalf("Wrong number of packets reported for %s, expected %d but got %d", typeString, nrecords, n)
+	if n != len(data) {
+		t.Fatalf("Wrong number of packets reported for %s, expected %d but got %d", typeString, len(data), n)
 	}
 
 	// iterate through packets
@@ -87,9 +87,9 @@ func testTable(t *testing.T, dType interface{}, data interface{}, nrecords int) 
 	// reset index
 	table.CreateIndex()
 
-	readdata := make([]particle, nrecords)
+	readdata := make([]particle, len(data))
 
-	if err = table.ReadPackets(0, nrecords, &readdata); err != nil {
+	if err = table.ReadPackets(0, len(data), &readdata); err != nil {
 		t.Fatalf("ReadPackets failed for %s: %s", typeString, err)
 	}
 
@@ -99,17 +99,6 @@ func testTable(t *testing.T, dType interface{}, data interface{}, nrecords int) 
 }
 
 func TestPTStruct(t *testing.T) {
-	// define an array of particles
-	particles := []particle{
-		{0, 0, 0, 0, 0, 0, 0, 0, 0.0, 0.0, false},
-		{10, 10, 10, 10, 10, 10, 10, 10, 1.0, 10.0, false},
-		{20, 20, 20, 20, 20, 20, 20, 20, 2.0, 20.0, false},
-		{30, 30, 30, 30, 30, 30, 30, 30, 3.0, 30.0, false},
-		{40, 40, 40, 40, 40, 40, 40, 40, 4.0, 40.0, true},
-		{50, 50, 50, 50, 50, 50, 50, 50, 5.0, 50.0, true},
-		{60, 60, 60, 60, 60, 60, 60, 60, 6.0, 60.0, true},
-		{70, 70, 70, 70, 70, 70, 70, 70, 7.0, 70.0, true},
-	}
 	// particles := []particle{
 	// 	{"zero", 0, 0, 0.0, 0., []int{0, 0}, [2][2]int{{0, 0}, {0, 0}}},
 	// 	{"one", 10, 10, 1.0, 10., []int{0, 0}, [2][2]int{{1, 0}, {0, 1}}},
@@ -119,84 +108,162 @@ func TestPTStruct(t *testing.T) {
 	// 	{"five", 50, 50, 5.0, 50., []int{0, 0}, [2][2]int{{5, 0}, {0, 5}}},
 	// 	{"six", 60, 60, 6.0, 60., []int{0, 0}, [2][2]int{{6, 0}, {0, 6}}},
 	// 	{"seven", 70, 70, 7.0, 70., []int{0, 0}, [2][2]int{{7, 0}, {0, 7}}},
-	// }
+	// } // TODO use array and strings when read is fixed.
 
-	testTable(t, particle{}, particles[0], 1)
-
-	parts := particles[1:]
-	testTable(t, particle{}, parts, 7)
+	testTable(t, particle{}, particle{0, 0, 0, 0, 0, 0, 0, 0, 0.0, 0.0, false})
+	testTable(t, particle{},
+		particle{10, 10, 10, 10, 10, 10, 10, 10, 1.0, 10.0, false},
+		particle{20, 20, 20, 20, 20, 20, 20, 20, 2.0, 20.0, false},
+		particle{30, 30, 30, 30, 30, 30, 30, 30, 3.0, 30.0, false},
+		particle{40, 40, 40, 40, 40, 40, 40, 40, 4.0, 40.0, true},
+		particle{50, 50, 50, 50, 50, 50, 50, 50, 5.0, 50.0, true},
+		particle{60, 60, 60, 60, 60, 60, 60, 60, 6.0, 60.0, true},
+		particle{70, 70, 70, 70, 70, 70, 70, 70, 7.0, 70.0, true},
+	)
 }
 
 func TestPTableBasic(t *testing.T) {
 	// INT8
-	i8s := []int8{-3, -2, -1, 0, 1, 2, 3, 4}
-	testTable(t, T_NATIVE_INT8, i8s[0], 1)
-	i8sub := i8s[1:]
-	testTable(t, T_NATIVE_INT8, i8sub, 7)
+	testTable(t, T_NATIVE_INT8, int8(-3))
+	testTable(t, T_NATIVE_INT8,
+		int8(-2),
+		int8(-1),
+		int8(0),
+		int8(1),
+		int8(2),
+		int8(3),
+		int8(4),
+	)
 
 	// INT16
-	i16s := []int16{-3, -2, -1, 0, 1, 2, 3, 4}
-	testTable(t, T_NATIVE_INT16, i16s[0], 1)
-	i16sub := i16s[1:]
-	testTable(t, T_NATIVE_INT16, i16sub, 7)
+	testTable(t, T_NATIVE_INT16, int16(-3))
+	testTable(t, T_NATIVE_INT16,
+		int16(-2),
+		int16(-1),
+		int16(0),
+		int16(1),
+		int16(2),
+		int16(3),
+		int16(4),
+	)
 
 	// INT32
-	i32s := []int32{-3, -2, -1, 0, 1, 2, 3, 4}
-	testTable(t, T_NATIVE_INT32, i32s[0], 1)
-	i32sub := i32s[1:]
-	testTable(t, T_NATIVE_INT32, i32sub, 7)
+	testTable(t, T_NATIVE_INT32, int32(-3))
+	testTable(t, T_NATIVE_INT32,
+		int32(-2),
+		int32(-1),
+		int32(0),
+		int32(1),
+		int32(2),
+		int32(3),
+		int32(4),
+	)
 
 	// INT64
-	i64s := []int64{-3, -2, -1, 0, 1, 2, 3, 4}
-	testTable(t, T_NATIVE_INT64, i64s[0], 1)
-	i64sub := i64s[1:]
-	testTable(t, T_NATIVE_INT64, i64sub, 7)
+	testTable(t, T_NATIVE_INT64, int64(-3))
+	testTable(t, T_NATIVE_INT64,
+		int64(-2),
+		int64(-1),
+		int64(0),
+		int64(1),
+		int64(2),
+		int64(3),
+		int64(4),
+	)
 
 	// UINT8
-	ui8s := []uint8{0, 1, 2, 3, 4, 5, 6, 7}
-	testTable(t, T_NATIVE_UINT8, ui8s[0], 1)
-	ui8sub := ui8s[1:]
-	testTable(t, T_NATIVE_UINT8, ui8sub, 7)
+	testTable(t, T_NATIVE_UINT8, uint8(0))
+	testTable(t, T_NATIVE_UINT8,
+		uint8(1),
+		uint8(2),
+		uint8(3),
+		uint8(4),
+		uint8(5),
+		uint8(6),
+		uint8(7),
+	)
 
 	// UINT16
-	ui16s := []uint16{0, 1, 2, 3, 4, 5, 6, 7}
-	testTable(t, T_NATIVE_UINT16, ui16s[0], 1)
-	ui16sub := ui16s[1:]
-	testTable(t, T_NATIVE_UINT16, ui16sub, 7)
+	testTable(t, T_NATIVE_UINT16, uint16(0))
+	testTable(t, T_NATIVE_UINT16,
+		uint16(1),
+		uint16(2),
+		uint16(3),
+		uint16(4),
+		uint16(5),
+		uint16(6),
+		uint16(7),
+	)
 
 	// UINT32
-	ui32s := []uint32{0, 1, 2, 3, 4, 5, 6, 7}
-	testTable(t, T_NATIVE_UINT32, ui32s[0], 1)
-	ui32sub := ui32s[1:]
-	testTable(t, T_NATIVE_UINT32, ui32sub, 7)
+	testTable(t, T_NATIVE_UINT32, uint32(0))
+	testTable(t, T_NATIVE_UINT32,
+		uint32(1),
+		uint32(2),
+		uint32(3),
+		uint32(4),
+		uint32(5),
+		uint32(6),
+		uint32(7),
+	)
 
 	// UINT64
-	ui64s := []uint64{0, 1, 2, 3, 4, 5, 6, 7}
-	testTable(t, T_NATIVE_UINT64, ui64s[0], 1)
-	ui64sub := ui64s[1:]
-	testTable(t, T_NATIVE_UINT64, ui64sub, 7)
+	testTable(t, T_NATIVE_UINT64, uint64(0))
+	testTable(t, T_NATIVE_UINT64,
+		uint64(1),
+		uint64(2),
+		uint64(3),
+		uint64(4),
+		uint64(5),
+		uint64(6),
+		uint64(7),
+	)
 
 	// FLOAT32
-	f32s := []float32{0., 1., 2., 3., 4., 5., 6., 7.}
-	testTable(t, T_NATIVE_FLOAT, f32s[0], 1)
-	f32sub := f32s[1:]
-	testTable(t, T_NATIVE_FLOAT, f32sub, 7)
+	testTable(t, T_NATIVE_FLOAT, float32(0))
+	testTable(t, T_NATIVE_FLOAT,
+		float32(1),
+		float32(2),
+		float32(3),
+		float32(4),
+		float32(5),
+		float32(6),
+		float32(7),
+	)
 
 	// FLOAT64
-	f64s := []float64{0., 1., 2., 3., 4., 5., 6., 7.}
-	testTable(t, T_NATIVE_DOUBLE, f64s[0], 1)
-	f64sub := f64s[1:]
-	testTable(t, T_NATIVE_DOUBLE, f64sub, 7)
+	testTable(t, T_NATIVE_DOUBLE, float64(0))
+	testTable(t, T_NATIVE_DOUBLE,
+		float64(1),
+		float64(2),
+		float64(3),
+		float64(4),
+		float64(5),
+		float64(6),
+		float64(7),
+	)
 
 	// BOOL
-	bs := []bool{false, true, false, true, false, true, false, true}
-	testTable(t, T_NATIVE_HBOOL, bs[0], 1)
-	bsub := bs[1:]
-	testTable(t, T_NATIVE_HBOOL, bsub, 7)
+	testTable(t, T_NATIVE_HBOOL, false)
+	testTable(t, T_NATIVE_HBOOL,
+		true,
+		false,
+		true,
+		false,
+		true,
+		false,
+		true,
+	)
 
 	// STRING
-	strs := []string{"zero", "one", "two", "three", "four", "five", "six", "seven"}
-	testTable(t, T_GO_STRING, strs[0], 1)
-	strsub := strs[1:]
-	testTable(t, T_GO_STRING, strsub, 7)
+	testTable(t, T_GO_STRING, "zero")
+	testTable(t, T_GO_STRING,
+		"one",
+		"two",
+		"three",
+		"four",
+		"five",
+		"six",
+		"seven",
+	)
 }


### PR DESCRIPTION
First and foremost: this is an experimental P/R that works. But the main purpose is for me to get your feedback and maybe we can work something out that is nice and could replace at least the suboptimal `C.realloc` calls.

As @sbinet pointed out in https://github.com/gonum/hdf5/pull/17, it could be nice to marshal data into a `[]byte`. I coulndn't wait, started coding on another branch, and this is the result:
- Replaced the nasty `C.realloc` calls with a simple `make` and `copy` to increase the `[]byte` size.
- Got rid of the `C.free` that was necessary as a result of the memory allocation.
- Experimented a bit and I think I found an acceptable way to find the "native" endianess of the machine. It seems to work as expected.
- Replaced most of the C types with Go-native ones.

What I was not able to achieve is to get rid of the usage of `unsafe` related things. I hope we can find a solution for that. If I am not mistaken, it is obviously a problem to marshal `C.float` and `C.double` into a `uint32` or `uint64` without using `unsafe.Pointer` and a cast. But while experimenting, I found the same for the `unsafe.Pointer` address to the `C.String`s, and the signed integers. A potential solution would have been to extend the `ad.buffer` by 8 bytes before the case statement and then just use `unsafe.Pointer` in those mentioned cases and for the unsigned integers e.g. a `nativeEndian.PutUint16` instead. But for consistency, I liked this solution more.

Furthermore, the strings are as they are. I think, limited by the HDF5 library itself, there is no other way for us to move away from that.

With that: I would be very glad about any input. There is no rush in getting this PR in, I just wanted to exchange thoughts with you guys on that.

If and only if we will get this in, I will change the commit message ;)