### PR TITLE
hdf5: removes finalizers

### DIFF
--- a/h5a.go
+++ b/h5a.go
@@ -10,10 +10,7 @@ package hdf5
 import "C"
 
 import (
-	"fmt"
-
 	"reflect"
-	"runtime"
 	"unsafe"
 )
 
@@ -23,7 +20,6 @@ type Attribute struct {
 
 func newAttribute(id C.hid_t) *Attribute {
 	d := &Attribute{Identifier{id}}
-	runtime.SetFinalizer(d, (*Attribute).finalizer)
 	return d
 }
 
@@ -46,12 +42,6 @@ func openAttribute(id C.hid_t, name string) (*Attribute, error) {
 		return nil, err
 	}
 	return newAttribute(hid), nil
-}
-
-func (s *Attribute) finalizer() {
-	if err := s.Close(); err != nil {
-		panic(fmt.Errorf("error closing attr: %s", err))
-	}
 }
 
 func (s *Attribute) Id() int {

--- a/h5d.go
+++ b/h5d.go
@@ -13,7 +13,6 @@ import (
 	"fmt"
 
 	"reflect"
-	"runtime"
 	"unsafe"
 )
 
@@ -23,7 +22,6 @@ type Dataset struct {
 
 func newDataset(id C.hid_t) *Dataset {
 	d := &Dataset{Identifier{id}}
-	runtime.SetFinalizer(d, (*Dataset).finalizer)
 	return d
 }
 
@@ -39,12 +37,6 @@ func createDataset(id C.hid_t, name string, dtype *Datatype, dspace *Dataspace, 
 		return nil, err
 	}
 	return newDataset(hid), nil
-}
-
-func (s *Dataset) finalizer() {
-	if err := s.Close(); err != nil {
-		panic(fmt.Errorf("error closing dset: %s", err))
-	}
 }
 
 // Close releases and terminates access to a dataset.

--- a/h5f.go
+++ b/h5f.go
@@ -12,7 +12,6 @@ import "C"
 
 import (
 	"fmt"
-	"runtime"
 	"unsafe"
 )
 
@@ -40,15 +39,8 @@ type File struct {
 	CommonFG
 }
 
-func (f *File) finalizer() {
-	if err := f.Close(); err != nil {
-		panic(fmt.Errorf("error closing file: %s", err))
-	}
-}
-
 func newFile(id C.hid_t) *File {
 	f := &File{CommonFG{Identifier{id}}}
-	runtime.SetFinalizer(f, (*File).finalizer)
 	return f
 }
 

--- a/h5g.go
+++ b/h5g.go
@@ -12,7 +12,6 @@ import "C"
 
 import (
 	"fmt"
-	"runtime"
 	"unsafe"
 )
 
@@ -38,7 +37,6 @@ func (g *CommonFG) CreateGroup(name string) (*Group, error) {
 		return nil, err
 	}
 	group := &Group{CommonFG{Identifier{hid}}}
-	runtime.SetFinalizer(group, (*Group).finalizer)
 	return group, nil
 }
 
@@ -62,12 +60,6 @@ func (g *Group) CreateAttributeWith(name string, dtype *Datatype, dspace *Datasp
 	return createAttribute(g.id, name, dtype, dspace, acpl)
 }
 
-func (g *Group) finalizer() {
-	if err := g.Close(); err != nil {
-		panic(fmt.Errorf("error closing group: %s", err))
-	}
-}
-
 // Close closes the Group.
 func (g *Group) Close() error {
 	if g.id == 0 {
@@ -88,7 +80,6 @@ func (g *CommonFG) OpenGroup(name string) (*Group, error) {
 		return nil, err
 	}
 	group := &Group{CommonFG{Identifier{hid}}}
-	runtime.SetFinalizer(group, (*Group).finalizer)
 	return group, nil
 }
 

--- a/h5p.go
+++ b/h5p.go
@@ -11,11 +11,6 @@ package hdf5
 // hid_t _go_hdf5_H5P_DEFAULT() { return H5P_DEFAULT; }
 import "C"
 
-import (
-	"fmt"
-	"runtime"
-)
-
 type PropType C.hid_t
 
 type PropList struct {
@@ -28,14 +23,7 @@ var (
 
 func newPropList(id C.hid_t) *PropList {
 	p := &PropList{Identifier{id}}
-	runtime.SetFinalizer(p, (*PropList).finalizer)
 	return p
-}
-
-func (p *PropList) finalizer() {
-	if err := p.Close(); err != nil {
-		panic(fmt.Errorf("error closing PropList: %s", err))
-	}
 }
 
 // NewPropList creates a new PropList as an instance of a property list class.

--- a/h5pt.go
+++ b/h5pt.go
@@ -14,7 +14,6 @@ import "C"
 import (
 	"fmt"
 	"reflect"
-	"runtime"
 	"unsafe"
 
 	"gonum.org/v1/hdf5/cmem"
@@ -27,14 +26,7 @@ type Table struct {
 
 func newPacketTable(id C.hid_t) *Table {
 	t := &Table{Identifier{id}}
-	runtime.SetFinalizer(t, (*Table).finalizer)
 	return t
-}
-
-func (t *Table) finalizer() {
-	if err := t.Close(); err != nil {
-		panic(fmt.Errorf("error closing packet table: %s", err))
-	}
 }
 
 // Close closes an open packet table.

--- a/h5s.go
+++ b/h5s.go
@@ -13,7 +13,6 @@ import (
 	"errors"
 	"fmt"
 
-	"runtime"
 	"unsafe"
 )
 
@@ -32,7 +31,6 @@ const (
 
 func newDataspace(id C.hid_t) *Dataspace {
 	ds := &Dataspace{Identifier{id}}
-	runtime.SetFinalizer(ds, (*Dataspace).finalizer)
 	return ds
 }
 
@@ -44,12 +42,6 @@ func CreateDataspace(class SpaceClass) (*Dataspace, error) {
 	}
 	ds := newDataspace(hid)
 	return ds, nil
-}
-
-func (s *Dataspace) finalizer() {
-	if err := s.Close(); err != nil {
-		panic(fmt.Errorf("error closing dspace: %s", err))
-	}
 }
 
 // Copy creates an exact copy of a dataspace.

--- a/h5t.go
+++ b/h5t.go
@@ -12,7 +12,6 @@ import "C"
 import (
 	"fmt"
 	"reflect"
-	"runtime"
 	"unsafe"
 )
 
@@ -109,7 +108,6 @@ func OpenDatatype(c CommonFG, name string, tapl_id int) (*Datatype, error) {
 // NewDatatype creates a Datatype from an hdf5 id.
 func NewDatatype(id C.hid_t) *Datatype {
 	t := &Datatype{Identifier{id}}
-	runtime.SetFinalizer(t, (*Datatype).finalizer)
 	return t
 }
 
@@ -132,12 +130,6 @@ func CreateDatatype(class TypeClass, size int) (*Datatype, error) {
 		return nil, err
 	}
 	return NewDatatype(hid), nil
-}
-
-func (t *Datatype) finalizer() {
-	if err := t.Close(); err != nil {
-		panic(fmt.Errorf("error closing datatype: %s", err))
-	}
 }
 
 // GoType returns the reflect.Type associated with the Datatype's TypeClass
@@ -212,7 +204,6 @@ func NewArrayType(base_type *Datatype, dims []int) (*ArrayType, error) {
 		return nil, err
 	}
 	t := &ArrayType{Datatype{Identifier{hid}}}
-	runtime.SetFinalizer(t, (*ArrayType).finalizer)
 	return t, nil
 }
 
@@ -250,7 +241,6 @@ func NewVarLenType(base_type *Datatype) (*VarLenType, error) {
 		return nil, err
 	}
 	t := &VarLenType{Datatype{Identifier{id}}}
-	runtime.SetFinalizer(t, (*VarLenType).finalizer)
 	return t, nil
 }
 
@@ -271,7 +261,6 @@ func NewCompoundType(size int) (*CompoundType, error) {
 		return nil, err
 	}
 	t := &CompoundType{Datatype{Identifier{id}}}
-	runtime.SetFinalizer(t, (*CompoundType).finalizer)
 	return t, nil
 }
 


### PR DESCRIPTION
As discussed in https://github.com/gonum/hdf5/issues/23

> As the finalizers are causing tremendous problems in production usage,
they were completely removed from all types that were using them. Therefore it is
required that the caller of the New* functions also take care of calling the Close() methods.