### PR TITLE
cmem: return error for invalid reflect.Value

### DIFF
--- a/cmem/encoder.go
+++ b/cmem/encoder.go
@@ -54,6 +54,10 @@ func (enc *Encoder) Encode(data interface{}) error {
 	}
 
 	rv := reflect.Indirect(reflect.ValueOf(data))
+	if !rv.IsValid() {
+		return fmt.Errorf("cmem: reflect.ValueOf returned invalid value for type %T", data)
+	}
+
 	rt := rv.Type()
 
 	switch rt.Kind() {


### PR DESCRIPTION
Once again: I noticed something fishy that we haven't taken care of. This is an actual problem using the PacketTable append. Instead of handleing the error in a nice way, the whole thing will just panic, as it is now. Therefore, I created this small fix. Hope you guys agree.

> In case reflect.ValueOf results in an invalid value, the code previously
caused a panic, which is not optimal for error handling.
This patch fixes that by returning an error in case reflect.ValueOf
resulted in an invalid value that cannot be used for further operations.
