### PR TITLE
hdf5: use correct width for ID return value

### DIFF
--- a/cmd/test-go-cpxcmpd/main.go
+++ b/cmd/test-go-cpxcmpd/main.go
@@ -67,7 +67,7 @@ func main() {
 		panic(err)
 	}
 	defer f.Close()
-	fmt.Printf(":: file [%s] created (id=%d)\n", fname, f.Id())
+	fmt.Printf(":: file [%s] created (id=%d)\n", fname, f.ID())
 
 	// create the memory data type
 	dtype, err := hdf5.NewDatatypeFromValue(s1[0])
@@ -80,7 +80,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	fmt.Printf(":: dset (id=%d)\n", dset.Id())
+	fmt.Printf(":: dset (id=%d)\n", dset.ID())
 
 	// write data to the dataset
 	fmt.Printf(":: dset.Write...\n")

--- a/cmd/test-go-table-01-readback/main.go
+++ b/cmd/test-go-table-01-readback/main.go
@@ -64,7 +64,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	fmt.Printf(":: file [%s] opened (id=%d)\n", f.Name(), f.Id())
+	fmt.Printf(":: file [%s] opened (id=%d)\n", f.Name(), f.ID())
 
 	// create a fixed-length packet table within the file
 	table, err := f.OpenTable(tname)

--- a/cmd/test-go-table-01/main.go
+++ b/cmd/test-go-table-01/main.go
@@ -60,7 +60,7 @@ func main() {
 		panic(fmt.Errorf("CreateFile failed: %s", err))
 	}
 	defer f.Close()
-	fmt.Printf(":: file [%s] created (id=%d)\n", fname, f.Id())
+	fmt.Printf(":: file [%s] created (id=%d)\n", fname, f.ID())
 
 	// create a fixed-length packet table within the file
 	table, err := f.CreateTableFrom(tname, particle{}, chunkSize, compress)
@@ -68,7 +68,7 @@ func main() {
 		panic(fmt.Errorf("CreateTableFrom failed: %s", err))
 	}
 	defer table.Close()
-	fmt.Printf(":: table [%s] created (id=%d)\n", tname, table.Id())
+	fmt.Printf(":: table [%s] created (id=%d)\n", tname, table.ID())
 
 	if !table.IsValid() {
 		panic("table is invalid")

--- a/h5a.go
+++ b/h5a.go
@@ -54,10 +54,6 @@ func (s *Attribute) finalizer() {
 	}
 }
 
-func (s *Attribute) Id() int {
-	return int(s.id)
-}
-
 // Access the type of an attribute
 func (s *Attribute) GetType() Identifier {
 	ftype := C.H5Aget_type(s.id)

--- a/h5i.go
+++ b/h5i.go
@@ -32,9 +32,9 @@ type Identifier struct {
 	id C.hid_t
 }
 
-// Id returns the int value of an identifier.
-func (i Identifier) Id() int {
-	return int(i.id)
+// ID returns the integer value of an identifier.
+func (i Identifier) ID() int64 {
+	return int64(i.id)
 }
 
 // Name returns the full name of the Identifier

--- a/h5pt.go
+++ b/h5pt.go
@@ -52,10 +52,6 @@ func (t *Table) IsValid() bool {
 	return C.H5PTis_valid(t.id) >= 0
 }
 
-func (t *Table) Id() int {
-	return int(t.id)
-}
-
 // ReadPackets reads a number of packets from a packet table.
 func (t *Table) ReadPackets(start, nrecords int, data interface{}) error {
 	c_start := C.hsize_t(start)

--- a/h5s.go
+++ b/h5s.go
@@ -71,10 +71,6 @@ func (s *Dataspace) Close() error {
 	return err
 }
 
-func (s *Dataspace) Id() int {
-	return int(s.id)
-}
-
 // CreateSimpleDataspace creates a new simple dataspace and opens it for access.
 func CreateSimpleDataspace(dims, maxDims []uint) (*Dataspace, error) {
 	var c_dims, c_maxdims *C.hsize_t


### PR DESCRIPTION
This is one of the things I noticed while wandering around over the past couple of days. There will be more. In particular, I'd like to use `Identifier` as the type that's passed between functions so that the user never actually needs to have a `C.hid_t` decl in their code (even implicitly).

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
