### PR TITLE
hdf5: remove finalizers from types that are components of returned types

### DIFF
--- a/h5t.go
+++ b/h5t.go
@@ -211,6 +211,7 @@ func NewArrayType(base_type *Datatype, dims []int) (*ArrayType, error) {
 	if err := checkID(hid); err != nil {
 		return nil, err
 	}
+	runtime.SetFinalizer(base_type, nil)
 	t := &ArrayType{Datatype{Identifier{hid}}}
 	runtime.SetFinalizer(t, (*ArrayType).finalizer)
 	return t, nil
@@ -249,6 +250,7 @@ func NewVarLenType(base_type *Datatype) (*VarLenType, error) {
 	if err := checkID(id); err != nil {
 		return nil, err
 	}
+	runtime.SetFinalizer(base_type, nil)
 	t := &VarLenType{Datatype{Identifier{id}}}
 	runtime.SetFinalizer(t, (*VarLenType).finalizer)
 	return t, nil
@@ -322,6 +324,7 @@ func (t *CompoundType) MemberType(mbr_idx int) (*Datatype, error) {
 func (t *CompoundType) Insert(name string, offset int, field *Datatype) error {
 	cname := C.CString(name)
 	defer C.free(unsafe.Pointer(cname))
+	runtime.SetFinalizer(field, nil)
 	return h5err(C.H5Tinsert(t.id, cname, C.size_t(offset), field.id))
 }
 


### PR DESCRIPTION
This retains finalizers and so reduces the risk of memory leaks, but removes them from `Datatype` values that are managed as part of compound, array or varlen types.

Please take a look.

Fixes #23.

/cc @TacoVox

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
