### PR TITLE
cmem: restore correct endianness in test

### DIFF
--- a/cmem/encoder_test.go
+++ b/cmem/encoder_test.go
@@ -42,7 +42,7 @@ func TestEncode(t *testing.T) {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			oldEndian := nativeEndian
 			nativeEndian = binary.LittleEndian
-			defer func() { oldEndian = nativeEndian }()
+			defer func() { nativeEndian = oldEndian }()
 			var enc Encoder
 			err := enc.Encode(tc.v)
 			if err != nil {


### PR DESCRIPTION
Fixes gonum/hdf5#30.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
