### PR TITLE
 use 'cgo pkg-config' for obtaining CFLAGS and LDFLAGS

### DIFF
--- a/cgoflags.go
+++ b/cgoflags.go
@@ -4,10 +4,7 @@
 
 package hdf5
 
-// #cgo LDFLAGS: -lhdf5 -lhdf5_hl
-// #cgo darwin CFLAGS: -I/usr/local/include
-// #cgo darwin LDFLAGS: -L/usr/local/lib
-// #cgo linux CFLAGS: -I/usr/local/include, -I/usr/lib/x86_64-linux-gnu/hdf5/serial/include
-// #cgo linux LDFLAGS: -L/usr/local/lib, -L/usr/lib/x86_64-linux-gnu/hdf5/serial/
+// #cgo pkg-config: hdf5
+// #cgo LDFLAGS: -lhdf5_hl
 // #include "hdf5.h"
 import "C"

--- a/cgoflags.go
+++ b/cgoflags.go
@@ -4,7 +4,7 @@
 
 package hdf5
 
-// #cgo pkg-config: hdf5
+// #cgo pkg-config: hdf5-serial
 // #cgo LDFLAGS: -lhdf5_hl
 // #include "hdf5.h"
 import "C"


### PR DESCRIPTION
with 'cgo pkg-config' directive to build on different platforms.