### PR TITLE
update CFLAGS and LDFLAGS to support raspbian

### DIFF
--- a/cgoflags.go
+++ b/cgoflags.go
@@ -7,7 +7,9 @@ package hdf5
 // #cgo LDFLAGS: -lhdf5 -lhdf5_hl
 // #cgo darwin CFLAGS: -I/usr/local/include
 // #cgo darwin LDFLAGS: -L/usr/local/lib
-// #cgo linux CFLAGS: -I/usr/local/include, -I/usr/lib/x86_64-linux-gnu/hdf5/serial/include
-// #cgo linux LDFLAGS: -L/usr/local/lib, -L/usr/lib/x86_64-linux-gnu/hdf5/serial/
+// #cgo linux !arm CFLAGS: -I/usr/local/include, -I/usr/lib/x86_64-linux-gnu/hdf5/serial/include
+// #cgo linux !arm LDFLAGS: -L/usr/local/lib, -L/usr/lib/x86_64-linux-gnu/hdf5/serial/
+// #cgo linux arm CFLAGS: -I/usr/local/include, -I/usr/lib/arm-linux-gnueabihf/hdf5/serial/include/
+// #cgo linux arm LDFLAGS: -L/usr/local/lib, -L/usr/lib/arm-linux-gnueabihf/hdf5/serial/
 // #include "hdf5.h"
 import "C"


### PR DESCRIPTION
modify cgoflags.go to support raspbian.  cgo pkg-config: hdf5 solution does not work with homebrew and ubuntu trusty, though it works on raspbian stretch and ubuntu 18.10.  