### PR TITLE
Add group attributes

### DIFF
--- a/h5d_dataset.go
+++ b/h5d_dataset.go
@@ -167,8 +167,7 @@ func (s *Dataset) CreateAttributeWith(name string, dtype *Datatype, dspace *Data
 }
 
 // Opens an existing attribute. The returned attribute must be closed
-// by the user when it is no longer needed. The returned attribute
-// must be closed by the user when it is no longer needed.
+// by the user when it is no longer needed.
 func (s *Dataset) OpenAttribute(name string) (*Attribute, error) {
 	return openAttribute(s.id, name)
 }

--- a/h5g_group.go
+++ b/h5g_group.go
@@ -67,8 +67,7 @@ func (g *Group) CreateAttributeWith(name string, dtype *Datatype, dspace *Datasp
 }
 
 // Opens an existing attribute. The returned attribute must be closed
-// by the user when it is no longer needed. The returned attribute
-// must be closed by the user when it is no longer needed.
+// by the user when it is no longer needed.
 func (g *Group) OpenAttribute(name string) (*Attribute, error) {
 	return openAttribute(g.id, name)
 }

--- a/h5g_group.go
+++ b/h5g_group.go
@@ -66,6 +66,13 @@ func (g *Group) CreateAttributeWith(name string, dtype *Datatype, dspace *Datasp
 	return createAttribute(g.id, name, dtype, dspace, acpl)
 }
 
+// Opens an existing attribute. The returned attribute must be closed
+// by the user when it is no longer needed. The returned attribute
+// must be closed by the user when it is no longer needed.
+func (g *Group) OpenAttribute(name string) (*Attribute, error) {
+	return openAttribute(s.id, name)
+}
+
 // Close closes the Group.
 func (g *Group) Close() error {
 	return g.closeWith(h5gclose)

--- a/h5g_group.go
+++ b/h5g_group.go
@@ -70,7 +70,7 @@ func (g *Group) CreateAttributeWith(name string, dtype *Datatype, dspace *Datasp
 // by the user when it is no longer needed. The returned attribute
 // must be closed by the user when it is no longer needed.
 func (g *Group) OpenAttribute(name string) (*Attribute, error) {
-	return openAttribute(s.id, name)
+	return openAttribute(g.id, name)
 }
 
 // Close closes the Group.


### PR DESCRIPTION
When porting access of an hdf5 file from Python to Go similar to 
```Python
import h5py

f = h5py.File('./examples/hdf5/data00000100.h5', 'r')
g = f['data/100']

for a in g.attrs:
    print(a, g.attrs[a])

# dumps...
# (u'dt', 3.2847121452090093e-16)
# (u'time', 3.2847121452090077e-14)
# (u'timeUnitSI', 1.0)
```
I noticed while `Groups` can have attributes and has same access pattern as `Datasets` the Go wrapper did not support them.  A simple c/p from `Datasets` appears to be working well. 
<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
