### PR TITLE
support for H5Lexist, Resize, Create&Read true colour images

### DIFF
--- a/h5d_dataset.go
+++ b/h5d_dataset.go
@@ -189,3 +189,20 @@ func (s *Dataset) Datatype() (*Datatype, error) {
 func (s *Dataset) hasIllegalGoPointer() bool {
 	return s.typ.hasIllegalGoPointer()
 }
+
+// Resize a dataset
+func (s *Dataset) Resize(dims []uint) error {
+	var c_dims *C.hsize_t
+	if dims == nil {
+		return fmt.Errorf("dims are nil")
+	}
+	rank := s.Space().SimpleExtentNDims()
+	if rank != len(dims) {
+		return fmt.Errorf("Resize can't change the rank of the dataset space")
+	}
+	c_dims = (*C.hsize_t)(unsafe.Pointer(&dims[0]))
+
+	rc := C.H5Dset_extent(s.id, c_dims)
+	err := h5err(rc)
+	return err
+}

--- a/h5g_group.go
+++ b/h5g_group.go
@@ -13,6 +13,7 @@ import "C"
 import (
 	"errors"
 	"fmt"
+	"image"
 	"unsafe"
 )
 
@@ -174,4 +175,13 @@ func (g *CommonFG) CheckLink(name string) error {
 		return nil
 	}
 	return errors.New("The link " + name + " does not exist or some other error occured")
+}
+
+// CreateTureImage create a image set with given name under a CommonFG
+func (g *CommonFG) CreateTrueImage(name string, img image.Image) error {
+	err := g.CheckLink(name)
+	if err == nil {
+		return errors.New("name already exist")
+	}
+	return newImage(g.id, name, img)
 }

--- a/h5g_group.go
+++ b/h5g_group.go
@@ -185,3 +185,11 @@ func (g *CommonFG) CreateTrueImage(name string, img image.Image) error {
 	}
 	return newImage(g.id, name, img)
 }
+
+func (g *CommonFG) ReadTrueImage(name string) (image.Image, error) {
+	err := g.CheckLink(name)
+	if err != nil {
+		return nil, errors.New("name doesn't exist")
+	}
+	return getImage(g.id, name)
+}

--- a/h5g_group.go
+++ b/h5g_group.go
@@ -11,6 +11,7 @@ package hdf5
 import "C"
 
 import (
+	"errors"
 	"fmt"
 	"unsafe"
 )
@@ -161,4 +162,16 @@ func (g *Group) CreateTableFrom(name string, dtype interface{}, chunkSize, compr
 // closed by the user when it is no longer needed.
 func (g *Group) OpenTable(name string) (*Table, error) {
 	return openTable(g.id, name)
+}
+
+// CheckLink checks if a link( can be group or dataset or actual link )exsit or not. This method won't give you annoying hdf5 warnings when called in a goroutine
+// CheckLink returns nil when a link exist, return an error when the link doesn't exist or some other error occured
+func (g *CommonFG) CheckLink(name string) error {
+	c_name := C.CString(name)
+	defer C.free(unsafe.Pointer(c_name))
+	status := C.H5Lexists(g.id, c_name, 0)
+	if status > 0 {
+		return nil
+	}
+	return errors.New("The link " + name + " does not exist or some other error occured")
 }

--- a/h5g_group_test.go
+++ b/h5g_group_test.go
@@ -5,6 +5,8 @@
 package hdf5
 
 import (
+	"image"
+	"image/color"
 	"os"
 	"testing"
 )
@@ -131,4 +133,31 @@ func TestGroup(t *testing.T) {
 		t.Errorf("opened dataset that was never created: %v", dset2)
 	}
 
+}
+
+func TestImage(t *testing.T) {
+	f, err := CreateFile(fname, F_ACC_TRUNC)
+	if err != nil {
+		t.Fatalf("CreateFile failed: %s", err)
+	}
+	defer os.Remove(fname)
+	defer f.Close()
+	img := image.NewRGBA(image.Rect(0, 0, 100, 50))
+	for y := 20; y < 30; y++ {
+		for x := 40; x < 60; x++ {
+			img.Set(x, y, color.RGBA{255, 0, 0, 255})
+		}
+	}
+	if err != nil {
+		t.Fatalf("image decoding failed: %s", err)
+	}
+	g1, err := f.CreateGroup("foo")
+	if err != nil {
+		t.Fatalf("couldn't create group: %s", err)
+	}
+	defer g1.Close()
+	err = g1.CreateTrueImage("image", img)
+	if err != nil {
+		t.Fatalf("image saving failed: %s", err)
+	}
 }

--- a/h5g_group_test.go
+++ b/h5g_group_test.go
@@ -17,6 +17,11 @@ func TestGroup(t *testing.T) {
 	defer os.Remove(fname)
 	defer f.Close()
 
+	err = f.CheckLink("/foo")
+	if err == nil {
+		t.Fatalf("err: %s", "/foo shouldn't exist at this time")
+	}
+
 	g1, err := f.CreateGroup("foo")
 	if err != nil {
 		t.Fatalf("couldn't create group: %s", err)
@@ -28,6 +33,16 @@ func TestGroup(t *testing.T) {
 		t.Errorf("wrong Name for group: want %q, got %q", "/foo", g1.Name())
 	}
 
+	err = f.CheckLink("/foo")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	err = g1.CheckLink("bar")
+	if err == nil {
+		t.Fatalf("err: %s", "/foo shouldn't have bar as a child at this time")
+	}
+
 	g2, err := g1.CreateGroup("bar")
 	if err != nil {
 		t.Fatalf("couldn't create group: %s", err)
@@ -37,6 +52,10 @@ func TestGroup(t *testing.T) {
 	}
 	if g2.Name() != "/foo/bar" {
 		t.Errorf("wrong Name for group: want %q, got %q", "/foo/bar", g1.Name())
+	}
+	err = g1.CheckLink("bar")
+	if err != nil {
+		t.Fatalf("err: %s", err)
 	}
 
 	g3, err := g2.CreateGroup("baz")

--- a/h5g_group_test.go
+++ b/h5g_group_test.go
@@ -7,6 +7,7 @@ package hdf5
 import (
 	"image"
 	"image/color"
+	"image/jpeg"
 	"os"
 	"testing"
 )
@@ -142,10 +143,10 @@ func TestImage(t *testing.T) {
 	}
 	defer os.Remove(fname)
 	defer f.Close()
-	img := image.NewRGBA(image.Rect(0, 0, 100, 50))
-	for y := 20; y < 30; y++ {
-		for x := 40; x < 60; x++ {
-			img.Set(x, y, color.RGBA{255, 0, 0, 255})
+	img := image.NewRGBA(image.Rect(0, 0, 1000, 500))
+	for y := 200; y < 300; y++ {
+		for x := 400; x < 600; x++ {
+			img.Set(x, y, color.RGBA{255, 0, 255, 255})
 		}
 	}
 	if err != nil {
@@ -160,4 +161,22 @@ func TestImage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("image saving failed: %s", err)
 	}
+	imgRead, err := g1.ReadTrueImage("image")
+	if err != nil {
+		t.Fatalf("image reading failed: %s", err)
+	}
+	widthGot := imgRead.Bounds().Max.X
+	heightGot := imgRead.Bounds().Max.Y
+	if widthGot != 1000 || heightGot != 500 {
+		t.Fatalf("image dimension miss match: Got %d * %d, suppose to be 1000x500", widthGot, heightGot)
+	}
+
+	imgfile, err := os.Create("img.jpg")
+	if err != nil {
+		t.Fatalf("image file creation failed: %s", err)
+	}
+	defer os.Remove("img.jpg")
+	defer imgfile.Close()
+
+	jpeg.Encode(imgfile, imgRead, nil)
 }

--- a/h5i_image.go
+++ b/h5i_image.go
@@ -1,0 +1,45 @@
+// license that can be found in the LICENSE file.
+
+package hdf5
+
+// #include "hdf5.h"
+// #include "hdf5_hl.h"
+// #include <stdlib.h>
+// #include <string.h>
+import "C"
+
+import (
+	"errors"
+	"image"
+	"unsafe"
+)
+
+// newImage takes a image object and convert it to a hdf5 format and write to the id node
+func newImage(id C.hid_t, name string, img image.Image) error {
+	if img == nil {
+		return errors.New("nil image!")
+	}
+	width := img.Bounds().Max.X
+	height := img.Bounds().Max.Y
+	var c_width, c_height C.hsize_t
+	c_name := C.CString(name)
+	defer C.free(unsafe.Pointer(c_name))
+	var gbuf []uint8
+	for y := 0; y < height; y++ {
+		for x := 0; x < width; x++ {
+			r, g, b, _ := img.At(x, y).RGBA()
+			gbuf = append(gbuf, uint8(r>>8))
+			gbuf = append(gbuf, uint8(g>>8))
+			gbuf = append(gbuf, uint8(b>>8))
+		}
+	}
+	c_width = C.hsize_t(width)
+	c_height = C.hsize_t(height)
+	c_image := (*C.uchar)(unsafe.Pointer(&gbuf[0]))
+
+	status := C.H5IMmake_image_24bit(id, c_name, c_width, c_height, C.CString("INTERLACE_PIXEL"), c_image)
+	if status < 0 {
+		return errors.New("Failed to create HDF5 true color image")
+	}
+	return nil
+}


### PR DESCRIPTION
Hi,
Please take a look.
I cleaned up my git history and limit 1 feature per commit:
1. `func (g *CommonFG) CheckLink(name string) error {}`
    A wrapper around C's [H5Lexists](https://support.hdfgroup.org/HDF5/doc/RM/RM_H5L.html#Link-Exists)
     returns error if the given link(can be group, dataset or link) not exist
2. `func (s *Dataset) Resize(dims []uint) error {}`
    A wrapper around C's [H5Dset_extent](https://support.hdfgroup.org/HDF5/doc/RM/RM_H5D.html#Dataset-SetExtent)
    Has some basic checking about the extended dimension

3. `func (g *CommonFG) CreateTrueImage(name string, img image.Image) error {}`
   Create a image dataset which can be viewed as image directly by hdf5 viewer 
   Wraps around [H5IMmake_image_24bit](https://support.hdfgroup.org/HDF5/doc/HL/RM_H5IM.html#H5IMmake_image_24bit)

4. `func (g *CommonFG) ReadTrueImage(name string) (image.Image, error) {}`
    Read a image dataset into image.Image struct
    Wraps around [H5IMget_image_info](https://support.hdfgroup.org/HDF5/doc/HL/RM_H5IM.html#H5IMget_image_info)  and [H5IMread_image](https://support.hdfgroup.org/HDF5/doc/HL/RM_H5IM.html#H5IMread_image)

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
