### PR TITLE
Adds support for aarch64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ go:
   - 1.12.x
   - master
 
+arch:
+  - amd64
+  - arm64
+
 matrix:
  fast_finish: true
  allow_failures:

--- a/cgoflags.go
+++ b/cgoflags.go
@@ -7,7 +7,9 @@ package hdf5
 // #cgo LDFLAGS: -lhdf5 -lhdf5_hl
 // #cgo darwin CFLAGS: -I/usr/local/include
 // #cgo darwin LDFLAGS: -L/usr/local/lib
-// #cgo linux CFLAGS: -I/usr/local/include, -I/usr/lib/x86_64-linux-gnu/hdf5/serial/include
-// #cgo linux LDFLAGS: -L/usr/local/lib, -L/usr/lib/x86_64-linux-gnu/hdf5/serial/
+// #cgo linux,!arm64 CFLAGS: -I/usr/local/include, -I/usr/lib/x86_64-linux-gnu/hdf5/serial/include
+// #cgo linux,!arm64 LDFLAGS: -L/usr/local/lib, -L/usr/lib/x86_64-linux-gnu/hdf5/serial/
+// #cgo linux,arm64 CFLAGS: -I/usr/local/include, -I/usr/lib/aarch64-linux-gnu/hdf5/serial/include
+// #cgo linux,arm64 LDFLAGS: -L/usr/local/lib, -L/usr/lib/aarch64-linux-gnu/hdf5/serial/
 // #include "hdf5.h"
 import "C"


### PR DESCRIPTION
This change modifies hdf5 so that it compiles and links on aarch64 architectures.