### PR TITLE
hdf5: add ObjectTypeByIndex to CommonFG

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,61 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+
+  build:
+    name: Build
+    strategy:
+      matrix:
+        go-version: [1.16.x, 1.15.x]
+        platform: [ubuntu-latest]
+
+    runs-on: ${{ matrix.platform }}
+    env:
+        GO111MODULE: on
+        GOPATH: ${{ github.workspace }}
+        GODEBUG: cgocheck=0
+    defaults:
+        run:
+            working-directory: ${{ env.GOPATH }}/src/gonum.org/v1/gonum
+
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go-version }}
+
+    - name: Cache-Go
+      uses: actions/cache@v1
+      with:
+        path: |
+            ~/go/pkg/mod              # Module download cache
+            ~/.cache/go-build         # Build cache (Linux)
+            ~/Library/Caches/go-build # Build cache (Mac)
+            '%LocalAppData%\go-build' # Build cache (Windows)
+
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+          path: ${{ env.GOPATH }}/src/gonum.org/v1/hdf5
+
+    - name: Install Linux packages
+      if: matrix.platform == 'ubuntu-latest'
+      run: |
+        sudo apt-get update
+        sudo apt-get install -qq pkg-config libhdf5-serial-dev
+
+    - name: Build
+      run: |
+        go install ./...
+
+    - name: Test
+      run: |
+        go test ./...

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # hdf5
 
+[![Build status](https://github.com/gonum/hdf5/workflows/CI/badge.svg)](https://github.com/gonum/hdf5/actions)
 [![Build Status](https://secure.travis-ci.org/gonum/hdf5.png)](http://travis-ci.org/gonum/hdf5)
 [![GoDoc](https://godoc.org/gonum.org/v1/hdf5?status.svg)](https://godoc.org/gonum.org/v1/hdf5)
 

--- a/README.md
+++ b/README.md
@@ -28,4 +28,4 @@ Naive ``cgo`` bindings for the ``C-API`` of ``hdf5``.
 
 ## License
 
-Please see github.com/gonum/license for general license information, contributors, authors, etc on the Gonum suite of packages.
+Please see github.com/gonum/gonum for general license information, contributors, authors, etc on the Gonum suite of packages.

--- a/h5g_group.go
+++ b/h5g_group.go
@@ -15,6 +15,37 @@ import (
 	"unsafe"
 )
 
+// GType describes the type of an object inside a Group or File.
+type GType int
+
+const (
+	H5G_UNKNOWN GType = C.H5G_UNKNOWN // Unknown object type
+	H5G_GROUP   GType = C.H5G_GROUP   // Object is a group
+	H5G_DATASET GType = C.H5G_DATASET // Object is a dataset
+	H5G_TYPE    GType = C.H5G_TYPE    // Object is a named data type
+	H5G_LINK    GType = C.H5G_LINK    // Object is a symbolic link
+	H5G_UDLINK  GType = C.H5G_UDLINK  // Object is a user-defined link
+)
+
+func (typ GType) String() string {
+	switch typ {
+	case H5G_UNKNOWN:
+		return "unknown"
+	case H5G_GROUP:
+		return "group"
+	case H5G_DATASET:
+		return "dataset"
+	case H5G_TYPE:
+		return "type"
+	case H5G_LINK:
+		return "link"
+	case H5G_UDLINK:
+		return "udlink"
+	default:
+		return fmt.Sprintf("GType(%d)", int(typ))
+	}
+}
+
 // CommonFG is for methods common to both File and Group
 type CommonFG struct {
 	Identifier
@@ -143,6 +174,17 @@ func (g *CommonFG) ObjectNameByIndex(idx uint) (string, error) {
 		return "", fmt.Errorf("could not get name")
 	}
 	return C.GoString(&name[0]), nil
+}
+
+// ObjectTypeByIndex returns the type of the object at idx.
+func (g *CommonFG) ObjectTypeByIndex(idx uint) (GType, error) {
+	cidx := C.hsize_t(idx)
+	gtyp := GType(C.H5Gget_objtype_by_idx(g.id, cidx))
+	if gtyp < H5G_GROUP {
+		return H5G_UNKNOWN, fmt.Errorf("could not get object type")
+	}
+
+	return gtyp, nil
 }
 
 // CreateTable creates a packet table to store fixed-length packets.

--- a/h5g_group_test.go
+++ b/h5g_group_test.go
@@ -71,6 +71,18 @@ func TestGroup(t *testing.T) {
 		t.Errorf("wrong number of objects in group: want 1, got %d", nObjs)
 	}
 
+	if name, err := g2.ObjectNameByIndex(0); err != nil {
+		t.Fatalf("could not retrieve object name idx=%d: %+v", 0, err)
+	} else if got, want := name, "baz"; got != want {
+		t.Errorf("invalid name for object idx=%d: got=%q, want=%q", 0, got, want)
+	}
+
+	if typ, err := g2.ObjectTypeByIndex(0); err != nil {
+		t.Fatalf("could not retrieve object type idx=%d: %+v", 0, err)
+	} else if got, want := typ, H5G_GROUP; got != want {
+		t.Errorf("invalid type for object idx=%d: got=%v, want=%v", 0, got, want)
+	}
+
 	err = g1.Close()
 	if err != nil {
 		t.Error(err)

--- a/h5i_identifier.go
+++ b/h5i_identifier.go
@@ -11,6 +11,7 @@ package hdf5
 import "C"
 
 import (
+	"fmt"
 	"unsafe"
 )
 
@@ -25,6 +26,27 @@ const (
 	ATTRIBUTE IType = C.H5I_ATTR
 	BAD_ID    IType = C.H5I_BADID
 )
+
+func (typ IType) String() string {
+	switch typ {
+	case FILE:
+		return "file"
+	case GROUP:
+		return "group"
+	case DATATYPE:
+		return "datatype"
+	case DATASPACE:
+		return "dataspace"
+	case DATASET:
+		return "dataset"
+	case ATTRIBUTE:
+		return "attribute"
+	case BAD_ID:
+		return "bad_id"
+	default:
+		return fmt.Sprintf("IType=%d", int(typ))
+	}
+}
 
 // Identifier is a simple wrapper around a C hid_t. It has basic methods
 // which apply to every type in the go-hdf5 API.


### PR DESCRIPTION
This CL adds a new method to CommonFG, ObjectTypeByIndex, to retrieve the type of an object in
a file or a group, prior to read from storage.

Fixes #77.
    
